### PR TITLE
fix: import error `'Badge' is imported from both`

### DIFF
--- a/lib/pricing_cards.dart
+++ b/lib/pricing_cards.dart
@@ -2,7 +2,7 @@
 library pricing_cards;
 
 import 'package:badges/badges.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
 
 /// The model to define data input for [PricingCards]
 class PricingCard {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: pricing_cards
 description: Awesome flexible pricing cards with custom style options for you Flutter project
-version: 0.0.7
+version: 0.0.8
 repository: https://github.com/f2acode/pricing_cards
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=1.20.0'
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This pull request resolves the error 
```
Error: 'Badge' is imported from both 
'package:badges/src/badge.dart' and 
'package:flutter/src/material/badge.dart'.
```
in projects with version 3.7.7 and above by importing `'material.dart'` and excluding `'Badge'`.
